### PR TITLE
sweep should run on wandb image, not tf image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,12 @@ WORKDIR /app
 COPY requirements.txt /app
 
 RUN pip install -r requirements.txt
+RUN pip install wandb
 
 COPY *.py /app/
-COPY *.sh /app/
 COPY Makefile /app
 
 ENV PYTHONPATH /app
+
+ARG WANDB_BASE_URL
+ENV WANDB_BASE_URL ${WANDB_BASE_URL}

--- a/Dockerfile.wandb
+++ b/Dockerfile.wandb
@@ -1,3 +1,5 @@
+# UNUSED
+
 ARG PARENT=tensorflow/tensorflow:1.15.0-gpu-py3
 
 FROM ${PARENT}

--- a/Makefile
+++ b/Makefile
@@ -60,4 +60,4 @@ start_sweep: wandb_container
 	--shm-size=1g --ulimit memlock=-1 -e CUDA_VISIBLE_DEVICES=0 \
 	-w /data/wandb_sweep -e WANDB_CONFIG_DIR=/data/wandb_sweep \
 	-e WANDB_USERNAME=${WANDB_USERNAME} -e WANDB_API_KEY=${WANDB_API_KEY} -e WANDB_PROJECT=${WANDB_PROJECT} \
-	${IMAGE_NAME} wandb agent ${WANDB_OPTION} ${SWEEP_ID}
+	${WANDB_IMAGE} wandb agent ${WANDB_OPTION} ${SWEEP_ID}

--- a/finetune_cifar10_wandb.yaml
+++ b/finetune_cifar10_wandb.yaml
@@ -22,7 +22,7 @@ command:
   - "--global_bn=False"
   - "--optimizer=momentum"
   - "--learning_rate=0.1"
-  - "--train_epochs=100"
+  - "--train_epochs=10"
   - "--train_batch_size=512"
   - "--warmup_epochs=0"
   - "--image_size=32"

--- a/simclr_wandb_test.md
+++ b/simclr_wandb_test.md
@@ -53,8 +53,9 @@ First create a W&B project simclr.
 
 
 Use the example sweep configuration in [finetune_cifar10_wandb.yaml](finetune_cifar10_wandb.yaml) to create a sweep.
-You'll also need a WANDB_DIR that contains this file.
-It will be loaded into the /data directory of the container.
+You'll also need a WANDB_DIR that contains this file and the pretrained model.
+It will be loaded into the `/data` directory of the container.
+I kept this separate from DATA_DIR.
 
 ```shell script
 make create_sweep WANDB_BASE_URL=... WANDB_DIR=... WANDB_USERNAME=... WANDB_API_KEY=... WANDB_PROJECT=simclr SWEEP_CONFIG=...
@@ -67,6 +68,10 @@ Record the sweep id, and use it in the next section.
 ```shell script
 make start_sweep WANDB_BASE_URL=... WANDB_DIR=... WANDB_USERNAME=... WANDB_API_KEY=... WANDB_PROJECT=simclr SWEEP_ID=...
 ```
+
+The sweeps don't log anything, so if you want to see performance,
+find the `ckpt_sweep` folder in your WANDB_DIR
+and run tensorboard with that as the `logdir`.
 
 ### Comparison
 

--- a/simclr_wandb_test.md
+++ b/simclr_wandb_test.md
@@ -10,10 +10,7 @@ When using wandb for grid search sweep of hyperparameters during simclr finetuni
 systematically. For the same set of parameters, the accuracy drops from over 90% to below 30%. 
 
 The change to add wandb API calls is minimal, from [run.py](run.py) (without using wandb) to 
-[run_sweep.py](run_sweep.py) (with wandb). There is only one additional dependency in the docker environment:
-```dockerfile
-RUN pip install wandb
-``` 
+[run_sweep.py](run_sweep.py) (with wandb).
 
 ### Set up
 
@@ -36,6 +33,7 @@ make simclr DATA_DIR=/host/path/data
 # inside docker
 tf-docker /app > make run_pretrain DATA_DIR=/data/cifar10 MODEL_DIR=/data/cifar10_model |& tee run_pretrain.log
 ```
+where `/host/path/data` is arbitrary.
 
 ### Finetune simclr with CIFAR-10
 
@@ -53,9 +51,13 @@ As a reference, the above runs on CIFAR-10 should give you around 91% accuracy, 
 
 First create a W&B project simclr.
 
-Use the example sweep configuration in [finetune_cifar10_wandb.yaml](finetune_cifar10_wandb.yaml) to create a sweep:
+
+Use the example sweep configuration in [finetune_cifar10_wandb.yaml](finetune_cifar10_wandb.yaml) to create a sweep.
+You'll also need a WANDB_DIR that contains this file.
+It will be loaded into the /data directory of the container.
+
 ```shell script
-make create_sweep WANDB_DIR=... WANDB_USERNAME=... WANDB_API_KEY=... WANDB_PROJECT=simclr SWEEP_CONFIG=...
+make create_sweep WANDB_BASE_URL=... WANDB_DIR=... WANDB_USERNAME=... WANDB_API_KEY=... WANDB_PROJECT=simclr SWEEP_CONFIG=...
 ```
 
 Record the sweep id, and use it in the next section.
@@ -63,7 +65,7 @@ Record the sweep id, and use it in the next section.
 ### Start W&B sweep
 
 ```shell script
-make start_sweep WANDB_DIR=... WANDB_USERNAME=... WANDB_API_KEY=... WANDB_PROJECT=simclr SWEEP_ID=...
+make start_sweep WANDB_BASE_URL=... WANDB_DIR=... WANDB_USERNAME=... WANDB_API_KEY=... WANDB_PROJECT=simclr SWEEP_ID=...
 ```
 
 ### Comparison


### PR DESCRIPTION
Hey Binwei:

I'm at W&B, working to repro the issue you reported. Thanks for the hard work on making the issue reproducible.

I only needed one tiny change to get it working: if I understand correctly, the `start_sweep` target should use the WANDB_IMAGE, rather than the IMAGE_NAME, because the goal is to execute a W&B sweep.

With this change, I was able to reproduce the performance hit you reported.